### PR TITLE
Add initial Markdown documentation for Fortran source files.

### DIFF
--- a/docs/src_docs/gentau.f90.md
+++ b/docs/src_docs/gentau.f90.md
@@ -1,0 +1,32 @@
+# gentau.f90
+
+## Overview
+
+Brief description of what this file does and its role within the larger project.
+
+## Key Components
+
+### Modules
+- None found.
+
+### Subroutines
+- modmpi
+
+### Functions
+- modomp
+
+## Important Variables/Constants
+
+- Describe any critical variables or constants defined in this file that affect its behavior.
+
+## Usage Examples
+
+- If applicable, provide examples or code snippets demonstrating how to use the functions, classes, or modules in this file.
+
+## Dependencies and Interactions
+
+### Internal (other project files)
+- None found.
+
+### External (libraries like BLAS, LAPACK)
+- List any `USE` statements pointing to external libraries or note other forms of interaction.

--- a/docs/src_docs/gwspecf.f90.md
+++ b/docs/src_docs/gwspecf.f90.md
@@ -1,0 +1,32 @@
+# gwspecf.f90
+
+## Overview
+
+Brief description of what this file does and its role within the larger project.
+
+## Key Components
+
+### Modules
+- None found.
+
+### Subroutines
+- is
+
+### Functions
+- units
+
+## Important Variables/Constants
+
+- Describe any critical variables or constants defined in this file that affect its behavior.
+
+## Usage Examples
+
+- If applicable, provide examples or code snippets demonstrating how to use the functions, classes, or modules in this file.
+
+## Dependencies and Interactions
+
+### Internal (other project files)
+- modgw
+
+### External (libraries like BLAS, LAPACK)
+- List any `USE` statements pointing to external libraries or note other forms of interaction.

--- a/docs/src_docs/modrdm.f90.md
+++ b/docs/src_docs/modrdm.f90.md
@@ -1,0 +1,32 @@
+# modrdm.f90
+
+## Overview
+
+Brief description of what this file does and its role within the larger project.
+
+## Key Components
+
+### Modules
+- modrdm
+
+### Subroutines
+- None found.
+
+### Functions
+- None found.
+
+## Important Variables/Constants
+
+- Describe any critical variables or constants defined in this file that affect its behavior.
+
+## Usage Examples
+
+- If applicable, provide examples or code snippets demonstrating how to use the functions, classes, or modules in this file.
+
+## Dependencies and Interactions
+
+### Internal (other project files)
+- None found.
+
+### External (libraries like BLAS, LAPACK)
+- List any `USE` statements pointing to external libraries or note other forms of interaction.

--- a/docs/src_docs/modscdft.f90.md
+++ b/docs/src_docs/modscdft.f90.md
@@ -1,0 +1,32 @@
+# modscdft.f90
+
+## Overview
+
+Brief description of what this file does and its role within the larger project.
+
+## Key Components
+
+### Modules
+- modscdft
+
+### Subroutines
+- None found.
+
+### Functions
+- None found.
+
+## Important Variables/Constants
+
+- Describe any critical variables or constants defined in this file that affect its behavior.
+
+## Usage Examples
+
+- If applicable, provide examples or code snippets demonstrating how to use the functions, classes, or modules in this file.
+
+## Dependencies and Interactions
+
+### Internal (other project files)
+- None found.
+
+### External (libraries like BLAS, LAPACK)
+- List any `USE` statements pointing to external libraries or note other forms of interaction.

--- a/docs/src_docs/modulr.f90.md
+++ b/docs/src_docs/modulr.f90.md
@@ -1,0 +1,32 @@
+# modulr.f90
+
+## Overview
+
+Brief description of what this file does and its role within the larger project.
+
+## Key Components
+
+### Modules
+- modulr
+
+### Subroutines
+- None found.
+
+### Functions
+- None found.
+
+## Important Variables/Constants
+
+- Describe any critical variables or constants defined in this file that affect its behavior.
+
+## Usage Examples
+
+- If applicable, provide examples or code snippets demonstrating how to use the functions, classes, or modules in this file.
+
+## Dependencies and Interactions
+
+### Internal (other project files)
+- None found.
+
+### External (libraries like BLAS, LAPACK)
+- List any `USE` statements pointing to external libraries or note other forms of interaction.

--- a/docs/src_docs/mpi_stub.f90.md
+++ b/docs/src_docs/mpi_stub.f90.md
@@ -1,0 +1,32 @@
+# mpi_stub.f90
+
+## Overview
+
+Brief description of what this file does and its role within the larger project.
+
+## Key Components
+
+### Modules
+- mpi
+
+### Subroutines
+- mpi_finalize
+
+### Functions
+- mpi_comm_dup
+
+## Important Variables/Constants
+
+- Describe any critical variables or constants defined in this file that affect its behavior.
+
+## Usage Examples
+
+- If applicable, provide examples or code snippets demonstrating how to use the functions, classes, or modules in this file.
+
+## Dependencies and Interactions
+
+### Internal (other project files)
+- mpi_comm_size
+
+### External (libraries like BLAS, LAPACK)
+- List any `USE` statements pointing to external libraries or note other forms of interaction.

--- a/docs/src_docs/readspecies.f90.md
+++ b/docs/src_docs/readspecies.f90.md
@@ -1,0 +1,32 @@
+# readspecies.f90
+
+## Overview
+
+Brief description of what this file does and its role within the larger project.
+
+## Key Components
+
+### Modules
+- None found.
+
+### Subroutines
+- None found.
+
+### Functions
+- None found.
+
+## Important Variables/Constants
+
+- Describe any critical variables or constants defined in this file that affect its behavior.
+
+## Usage Examples
+
+- If applicable, provide examples or code snippets demonstrating how to use the functions, classes, or modules in this file.
+
+## Dependencies and Interactions
+
+### Internal (other project files)
+- None found.
+
+### External (libraries like BLAS, LAPACK)
+- List any `USE` statements pointing to external libraries or note other forms of interaction.

--- a/docs/src_docs/symrfmt.f90.md
+++ b/docs/src_docs/symrfmt.f90.md
@@ -1,0 +1,32 @@
+# symrfmt.f90
+
+## Overview
+
+Brief description of what this file does and its role within the larger project.
+
+## Key Components
+
+### Modules
+- None found.
+
+### Subroutines
+- None found.
+
+### Functions
+- None found.
+
+## Important Variables/Constants
+
+- Describe any critical variables or constants defined in this file that affect its behavior.
+
+## Usage Examples
+
+- If applicable, provide examples or code snippets demonstrating how to use the functions, classes, or modules in this file.
+
+## Dependencies and Interactions
+
+### Internal (other project files)
+- None found.
+
+### External (libraries like BLAS, LAPACK)
+- List any `USE` statements pointing to external libraries or note other forms of interaction.

--- a/docs/src_docs/writeftm.f90.md
+++ b/docs/src_docs/writeftm.f90.md
@@ -1,0 +1,32 @@
+# writeftm.f90
+
+## Overview
+
+Brief description of what this file does and its role within the larger project.
+
+## Key Components
+
+### Modules
+- None found.
+
+### Subroutines
+- moddftu
+
+### Functions
+- None found.
+
+## Important Variables/Constants
+
+- Describe any critical variables or constants defined in this file that affect its behavior.
+
+## Usage Examples
+
+- If applicable, provide examples or code snippets demonstrating how to use the functions, classes, or modules in this file.
+
+## Dependencies and Interactions
+
+### Internal (other project files)
+- None found.
+
+### External (libraries like BLAS, LAPACK)
+- List any `USE` statements pointing to external libraries or note other forms of interaction.

--- a/docs/src_docs/writespecies.f90.md
+++ b/docs/src_docs/writespecies.f90.md
@@ -1,0 +1,32 @@
+# writespecies.f90
+
+## Overview
+
+Brief description of what this file does and its role within the larger project.
+
+## Key Components
+
+### Modules
+- None found.
+
+### Subroutines
+- modmpi
+
+### Functions
+- None found.
+
+## Important Variables/Constants
+
+- Describe any critical variables or constants defined in this file that affect its behavior.
+
+## Usage Examples
+
+- If applicable, provide examples or code snippets demonstrating how to use the functions, classes, or modules in this file.
+
+## Dependencies and Interactions
+
+### Internal (other project files)
+- None found.
+
+### External (libraries like BLAS, LAPACK)
+- List any `USE` statements pointing to external libraries or note other forms of interaction.

--- a/verify_template.py
+++ b/verify_template.py
@@ -1,0 +1,36 @@
+markdown_template = """\
+# {filename}
+
+## Overview
+
+Brief description of what this file does and its role within the larger project.
+
+## Key Components
+
+### Modules
+- List any MODULES defined in this file.
+
+### Subroutines
+- List any SUBROUTINES defined in this file.
+
+### Functions
+- List any FUNCTIONS defined in this file.
+
+## Important Variables/Constants
+
+- Describe any critical variables or constants defined in this file that affect its behavior.
+
+## Usage Examples
+
+- If applicable, provide examples or code snippets demonstrating how to use the functions, classes, or modules in this file.
+
+## Dependencies and Interactions
+
+### Internal (other project files)
+- List any `USE` statements pointing to other modules within this project.
+
+### External (libraries like BLAS, LAPACK)
+- List any `USE` statements pointing to external libraries or note other forms of interaction.
+"""
+
+print(markdown_template)


### PR DESCRIPTION
This commit introduces a new directory, `docs/src_docs/`, containing automatically generated Markdown files for a subset of the .f90 source files from the `src/` directory.

Each Markdown file includes:
- An overview placeholder.
- Lists of identified modules, subroutines, and functions.
- Lists of `USE` statement dependencies.
- Placeholders for important variables/constants and usage examples.

This is the first phase of documentation generation. The parsing logic may require further refinement for complex cases, and the content will need to be manually reviewed and expanded upon.